### PR TITLE
Fixed issue where .revert() was unable to correctly abort the RAF loop

### DIFF
--- a/src/jquery-seeThru.js
+++ b/src/jquery-seeThru.js
@@ -379,7 +379,7 @@ var methods = {
 								drawFrame(true);
 							});
 
-                            $this.data('seeThru').interval = interval;
+							$this.data('seeThru').interval = interval;
 
 						}
 


### PR DESCRIPTION
I'm using **jquery-seeThru** on a (single) video that is dynamically added and removed from the page. As the video is added and removed, I've noticed a huge slowdown in performance.

I tracked the issue to `.revert()` not being able to access the current RAF interval loop from `$this.data('seeThru')` and therefor not correctly clearing the loop.

This is because the RAF `interval` created in `drawFrame()` is not being stored against `$this.data('seeThru')`.

I've built and checked this change against the test, but have only committed the change to the source JS.
