### PR TITLE
Prevent redraw of same frame

### DIFF
--- a/src/seeThru.js
+++ b/src/seeThru.js
@@ -248,11 +248,12 @@
 		, interval
 		, requestAnimationFrame = window.requestAnimationFrame || getRequestAnimationFrame()
 		, cancelAnimationFrame = window.cancelAnimationFrame || getCancelAnimationFrame()
+		, lastDrawnFrameTime = null
 		, drawFrame = function(recurse){
-			var image, alphaData, i, len, currentTime = video.currentTime;
+			var image, alphaData, i, len, currentFrameTime = video.currentTime;
 			
-			if (lastFrameTime !== currentTime) {
-				lastFrameTime = currentTime;
+			if (lastDrawnFrameTime !== currentFrameTime) {
+				lastDrawnFrameTime = currentFrameTime;
 
 				buffer.drawImage(video, 0, 0, dimensions.width, dimensions.height * divisor); //scales if <video>-dimensions are not matching
 				image = buffer.getImageData(0, 0, dimensions.width, dimensions.height);


### PR DESCRIPTION
Drawing frames is a relatively expensive operation. If the currentTime and the time of the previous drawn frame are the same a repaint is not necessary. This can happen during playback but also if  the video element is in a paused state (my current use case).