### PR TITLE
Add Alternative CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ $ bower install seethru
 CDN:
 ```html
 <script src="https://unpkg.com/seethru@3/dist/seeThru.min.js"></script>
+<!-- or -->
+<script src="https://cdn.jsdelivr.net/npm/seethru@3/dist/seeThru.min.js"></script>
 ```
 
 Alternatively, use the version(s) in `/dist`.


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/seethru) to your readme as an alternative to unpkg. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg, but offers a larger network and better reliability.